### PR TITLE
Update deployment.yaml

### DIFF
--- a/charts/op-scim-bridge/templates/deployment.yaml
+++ b/charts/op-scim-bridge/templates/deployment.yaml
@@ -89,10 +89,6 @@ spec:
             runAsUser: 999
             runAsGroup: 999
             allowPrivilegeEscalation: false
-          {{- with .Values.scim.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- with .Values.scim.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -175,3 +171,7 @@ spec:
               mountPath: "/home/opuser/.op"
               readOnly: false
           {{- end }}
+      {{- with .Values.scim.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}


### PR DESCRIPTION
The ImagePullSecrets section is seen as "unknown" if placed under the container section whenever a value for ImagePullSecrets was provided in the values.yaml file. It has to be nested at the same level of the container section, under the spec section

## Overview

* Provide a detailed description of the changes, the problem that's being 
addressed and how this is objectively a worthwhile addition to the project.

## Changes

* List the changes that you made

-----------------------------------------------------------------------

## Checklist

- [ ] review the [guide to contributing](https://github.com/1Password/op-scim-helm/blob/main/CONTRIBUTING.md)
